### PR TITLE
Added initial support for SPDK

### DIFF
--- a/linstor_client/commands/storpool_cmds.py
+++ b/linstor_client/commands/storpool_cmds.py
@@ -44,6 +44,10 @@ class StoragePoolCommands(Commands):
         LONG = "filethin"
         SHORT = "filethin"
 
+    class SPDK(object):
+        LONG = "spdk"
+        SHORT = "spdk"
+
     _stor_pool_headers = [
         linstor_client.TableHeader("StoragePool"),
         linstor_client.TableHeader("Node"),
@@ -102,7 +106,8 @@ class StoragePoolCommands(Commands):
             StoragePoolCommands.File,
             StoragePoolCommands.FileThin,
             StoragePoolCommands.SwordfishTarget,
-            StoragePoolCommands.SwordfishInitiator
+            StoragePoolCommands.SwordfishInitiator,
+            StoragePoolCommands.SPDK
         ]
 
         sp_c_parser = sp_subp.add_parser(
@@ -129,6 +134,21 @@ class StoragePoolCommands(Commands):
             help='The Lvm volume group to use.'
         )
         p_new_lvm_pool.set_defaults(func=self.create, driver=linstor.StoragePoolDriver.LVM)
+
+        p_new_spdk_pool = create_subp.add_parser(
+            StoragePoolCommands.SPDK.LONG,
+            aliases=[StoragePoolCommands.SPDK.SHORT],
+            description='Create a spdk storage pool'
+        )
+        self._create_pool_args(p_new_spdk_pool)
+        p_new_spdk_pool.add_argument(
+            'driver_pool_name',
+            type=str,
+            help='The Spdk volume group to use.'
+        )
+        p_new_spdk_pool.set_defaults(func=self.create, driver=linstor.StoragePoolDriver.SPDK)
+
+
 
         p_new_lvm_thin_pool = create_subp.add_parser(
             StoragePoolCommands.LvmThin.LONG,


### PR DESCRIPTION
This pull request introduces to Linstor a possibility to create a storage pool from SPDK lvol store, construct SPDK lvol bdev and expose it as SPDK nvmf subsystem.

How to start using it:
1. Download and compile [SPDK v19.07](https://github.com/spdk/spdk/releases/tag/v19.07)
2. Setup SPDK
`spdk-19.07/scripts/setup.sh`
3. Start SPDK nvmf_tgt
`spdk-19.07/app/nvmf_tgt/nvmf_tgt`
4. Create SPDK nvme bdev from a drive
`spdk-19.07/scripts/rpc.py construct_nvme_bdev -b NVMe1 -t PCIe -a 0000:3e:00.0`
5. Create SPDK lvol store on the nvme bdev
`spdk-19.07/scripts/rpc.py construct_lvol_store NVMe1n1 sample-lvol-store`
6. Create a symlink to SPDK rpc.py script
`ln -s spdk-19.07/scripts/rpc.py /usr/bin/rpc.py`
7. Start Linstor and create a SPDK storage pool and a resource from it
```
linstor node create sample-node 10.1.0.1 --node-type Combined
linstor storage-pool-definition create spdk-pool
linstor storage-pool create spdk sample-node spdk-pool sample-lvol-store
linstor resource-definition create sample-resource
linstor volume-definition create sample-resource 10G
linstor resource create --layer-list nvme,storage --storage-pool spdk-pool sample-node sample-resource
```